### PR TITLE
feat: add email signup section with Formspree integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ You can begin editing the site from `app/page.tsx`. The page auto-updates as you
 - **TypeScript**
 - **ESLint**
 - **Lucide React** (Icon Library)
-- **Vercel** (Deployment)
 
 ---
 
@@ -75,6 +74,7 @@ You can begin editing the site from `app/page.tsx`. The page auto-updates as you
 - [x] PR template
 - [x] Landing layout
 - [x] Mission & CTA section
+- [x] Email Signup component
 - [ ] Deploy to Vercel
 
 ---

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
-import '@/styles/globals.css';
-import Footer from '@/components/Footer';
+import '@/styles/globals.css'
+import Footer from '@/components/Footer'
 import { ReactNode } from 'react'
-import Navbar from '@/components/Navbar';
+import Navbar from '@/components/Navbar'
 
 export const metadata = {
   title: 'Newriive',
@@ -25,8 +25,6 @@ export const metadata = {
     type: 'website',
   },
 }
-
-
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ export const metadata = {
     ],
     type: 'website',
   },
+  metadataBase: new URL('https://newriive.com'),
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Hero from '@/components/Hero'
 import ProblemSolution from '@/components/ProblemSolution'
 import ComingSoon from '@/components/ComingSoon'
-import CallToAction from '@/components/CallToAction'
+// import CallToAction from '@/components/CallToAction'
 import EmailSignup from '@/components/EmailSignup'
 
 export default function Home() {
@@ -11,7 +11,7 @@ export default function Home() {
       <ProblemSolution />
       <ComingSoon />
       <EmailSignup />
-      <CallToAction />
+      {/* <CallToAction /> */}
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Hero from '@/components/Hero'
 import ProblemSolution from '@/components/ProblemSolution'
 import ComingSoon from '@/components/ComingSoon'
 import CallToAction from '@/components/CallToAction'
+import EmailSignup from '@/components/EmailSignup'
 
 export default function Home() {
   return (
@@ -9,6 +10,7 @@ export default function Home() {
       <Hero />
       <ProblemSolution />
       <ComingSoon />
+      <EmailSignup />
       <CallToAction />
     </main>
   )

--- a/components/CallToAction.tsx
+++ b/components/CallToAction.tsx
@@ -2,8 +2,12 @@ export default function CallToAction() {
   return (
     <section className="py-12 sm:py-16 md:py-24 px-4 text-center bg-[#F5FBFA]">
       <div className="max-w-xl mx-auto">
-        <h2 className="text-xl sm:text-2xl font-semibold mb-4">Be Part of the Journey</h2>
-        <p className="mb-6 text-gray-700 text-base sm:text-lg">Newriive is still in early development. Join us as we grow.</p>
+        <h2 className="text-xl sm:text-2xl font-semibold mb-4">
+          Be Part of the Journey
+        </h2>
+        <p className="mb-6 text-gray-700 text-base sm:text-lg">
+          Newriive is still in early development. Join us as we grow.
+        </p>
         <button className="w-full sm:w-auto bg-[#2BB3A3] text-white px-6 py-3 rounded-full hover:bg-[#229f91] transition">
           Follow the Progress
         </button>

--- a/components/ComingSoon.tsx
+++ b/components/ComingSoon.tsx
@@ -2,7 +2,9 @@ export default function ComingSoon() {
   return (
     <section className="py-12 sm:py-16 md:py-24 px-4 text-center bg-gray-50">
       <div className="max-w-2xl mx-auto">
-        <h2 className="text-2xl sm:text-3xl font-semibold mb-6">What You’ll Be Able To Do</h2>
+        <h2 className="text-2xl sm:text-3xl font-semibold mb-6">
+          What You’ll Be Able To Do
+        </h2>
         <ul className="space-y-4 text-gray-700 text-base sm:text-lg">
           <li>✅ Get clarity on legal processes</li>
           <li>✅ Find curated resources for your journey</li>

--- a/components/EmailSignup.tsx
+++ b/components/EmailSignup.tsx
@@ -30,7 +30,7 @@ export default function EmailSignup() {
         <h2 className="text-2xl font-semibold mb-4">Stay in the loop</h2>
 
         {submitted ? (
-          <p className="text-green-600">Thanks! You're subscribed.</p>
+          <p className="text-green-600">Thanks! You&apos;re subscribed.</p>
         ) : (
           <form
             onSubmit={handleSubmit}

--- a/components/EmailSignup.tsx
+++ b/components/EmailSignup.tsx
@@ -1,4 +1,3 @@
-
 'use client'
 
 import { useState } from 'react'
@@ -28,9 +27,7 @@ export default function EmailSignup() {
   return (
     <section className="w-full py-16">
       <div className="max-w-2xl mx-auto px-4 text-center">
-        <h2 className="text-2xl font-semibold mb-4">
-          Stay in the loop
-        </h2>
+        <h2 className="text-2xl font-semibold mb-4">Stay in the loop</h2>
 
         {submitted ? (
           <p className="text-green-600">Thanks! You're subscribed.</p>
@@ -39,7 +36,9 @@ export default function EmailSignup() {
             onSubmit={handleSubmit}
             className="flex flex-col sm:flex-row gap-4 justify-center"
           >
-            <label htmlFor="email" className="sr-only">Email address</label>
+            <label htmlFor="email" className="sr-only">
+              Email address
+            </label>
             <input
               type="email"
               id="email"

--- a/components/EmailSignup.tsx
+++ b/components/EmailSignup.tsx
@@ -1,0 +1,63 @@
+
+'use client'
+
+import { useState } from 'react'
+
+export default function EmailSignup() {
+  const [email, setEmail] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const res = await fetch('https://formspree.io/f/xyzjzplz', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email }),
+    })
+
+    if (res.ok) {
+      setSubmitted(true)
+      setEmail('')
+    }
+  }
+
+  return (
+    <section className="w-full py-16">
+      <div className="max-w-2xl mx-auto px-4 text-center">
+        <h2 className="text-2xl font-semibold mb-4">
+          Stay in the loop
+        </h2>
+
+        {submitted ? (
+          <p className="text-green-600">Thanks! You're subscribed.</p>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col sm:flex-row gap-4 justify-center"
+          >
+            <label htmlFor="email" className="sr-only">Email address</label>
+            <input
+              type="email"
+              id="email"
+              required
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full sm:w-auto flex-1 border border-gray-300 px-4 py-2 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition"
+            >
+              Subscribe
+            </button>
+          </form>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/components/EmailSignup.tsx
+++ b/components/EmailSignup.tsx
@@ -50,7 +50,7 @@ export default function EmailSignup() {
             />
             <button
               type="submit"
-              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition"
+              className="bg-black text-white px-6 py-2 rounded-full text-sm font-medium hover:bg-gray-800 transition"
             >
               Subscribe
             </button>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,8 @@
 export default function Footer() {
   return (
     <footer className="py-8 text-center text-gray-500 text-sm bg-white">
-      &copy; {new Date().getFullYear()} Newriive. Built with care for those who move.
+      &copy; {new Date().getFullYear()} Newriive. Built with care for those who
+      move.
     </footer>
   )
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,7 +6,8 @@ export default function Hero() {
           Welcome to Newriive
         </h1>
         <p className="text-base sm:text-lg md:text-xl max-w-2xl mx-auto mb-6">
-          Tools, guidance, and community — designed for immigrants starting a new chapter.
+          Tools, guidance, and community — designed for immigrants starting a
+          new chapter.
         </p>
         <button className="w-full sm:w-auto bg-[#2BB3A3] text-white px-6 py-3 rounded-full hover:bg-[#229f91] transition">
           Learn More

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,10 +11,14 @@ export default function Navbar() {
         </Link>
         <ul className="flex space-x-6 text-gray-700 text-sm font-medium">
           <li>
-            <Link href="/about" className="hover:text-[#2BB3A3] transition">About</Link>
+            <Link href="/about" className="hover:text-[#2BB3A3] transition">
+              About
+            </Link>
           </li>
           <li>
-            <Link href="/join" className="hover:text-[#2BB3A3] transition">Join</Link>
+            <Link href="/join" className="hover:text-[#2BB3A3] transition">
+              Join
+            </Link>
           </li>
         </ul>
       </nav>

--- a/components/ProblemSolution.tsx
+++ b/components/ProblemSolution.tsx
@@ -2,16 +2,21 @@ export default function ProblemSolution() {
   return (
     <section className="py-12 sm:py-16 md:py-24 px-4 text-center bg-white">
       <div className="max-w-3xl mx-auto">
-        <h2 className="text-2xl sm:text-3xl font-semibold mb-6">The Challenge</h2>
+        <h2 className="text-2xl sm:text-3xl font-semibold mb-6">
+          The Challenge
+        </h2>
         <p className="text-base sm:text-lg text-gray-700 mb-6">
-          Navigating life in a new country is hard. From legal paperwork to culture shock to career questions,
-          it’s easy to feel overwhelmed and alone.
+          Navigating life in a new country is hard. From legal paperwork to
+          culture shock to career questions, it’s easy to feel overwhelmed and
+          alone.
         </p>
 
-        <h2 className="text-2xl sm:text-3xl font-semibold mt-12 mb-6">Our Vision</h2>
+        <h2 className="text-2xl sm:text-3xl font-semibold mt-12 mb-6">
+          Our Vision
+        </h2>
         <p className="text-base sm:text-lg text-gray-700">
-          Newriive is building a one-stop platform to guide and support immigrants — with tools,
-          shared knowledge, and human-centered design.
+          Newriive is building a one-stop platform to guide and support
+          immigrants — with tools, shared knowledge, and human-centered design.
         </p>
       </div>
     </section>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,16 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
-});
+})
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+]
 
-export default eslintConfig;
+export default eslintConfig

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,10 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   output: 'export',
   images: {
     unoptimized: true,
   },
-};
+}
 
-export default nextConfig;
+export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
+        "prettier": "^3.5.3",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -4685,6 +4686,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "lucide-react": "^0.513.0",
@@ -22,6 +23,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
+    "prettier": "^3.5.3",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "deploy": "npm run build && aws s3 sync ./out s3://newriive-site --delete"
   },
   "dependencies": {
     "lucide-react": "^0.513.0",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
+  plugins: ['@tailwindcss/postcss'],
+}
 
-export default config;
+export default config

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #ffffff;


### PR DESCRIPTION
## Summary  
This PR introduces a responsive and visually consistent email signup section to the homepage. Users can now subscribe to updates via a connected Formspree endpoint.

## Changes
- Created `components/EmailSignup.tsx` with minimal Tailwind styling
- Integrated with real Formspree form ID
- Placed the section after `<ComingSoon />` and before `<CallToAction />` on the homepage
- Matched design and spacing to existing layout
- Removed dark background and shadow from earlier version

## Preview  
The signup form is now live and aligned with the rest of the site:  
[https://newriive-site.s3.us-east-2.amazonaws.com/index.html](https://newriive-site.s3.us-east-2.amazonaws.com/index.html)

## Checklist
- [x] Component created  
- [x] Responsive layout  
- [x] Formspree endpoint added  
- [x] Matches site's design language  
- [x] Successfully deployed to S3 for preview
